### PR TITLE
Fix quoting in ibus test script

### DIFF
--- a/spec_files/ibus/tests/roles/ibus-desktop-testing-role/files/check-results.sh
+++ b/spec_files/ibus/tests/roles/ibus-desktop-testing-role/files/check-results.sh
@@ -43,7 +43,7 @@ if [ $TEST_RUN_IN_RAWHIDE -eq 0 ] ; then
         exit 0
     fi
 fi
-if [ ! -f $TEST_LOG ] ; then
+if [ ! -f "$TEST_LOG" ] ; then
     gen_results "0" "fail"
     echo -n ERROR
 else


### PR DESCRIPTION
## Summary
- ensure test log check is quoted to avoid word splitting

## Testing
- `bash spec_files/ibus/tests/roles/ibus-desktop-testing-role/files/check-results.sh --help || true`

------
https://chatgpt.com/codex/tasks/task_e_685a8f95a768832d919c6dc741a83341