### PR TITLE
Fix dnf5-setopt exit code

### DIFF
--- a/build_files/dnf5-setopt
+++ b/build_files/dnf5-setopt
@@ -8,7 +8,7 @@ die() {
     done
     echo >&2 "${*:-Something went wrong}"
     echo >&1 ":"
-    exit 0
+    exit 1
 }
 trap 'die' ERR
 


### PR DESCRIPTION
## Summary
- make `dnf5-setopt` exit with a non-zero status when errors occur

## Testing
- `bash -n build_files/dnf5-setopt`


------
https://chatgpt.com/codex/tasks/task_e_685a8db5e4cc832d9d1a88d7ad64cfff