### PR TITLE
Fix GRUB timeout checks

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -356,14 +356,14 @@ touch /etc/bazzite/fixups/snapper_cleanup
 if [ ! -f /etc/bazzite/fixups/grub_fixup ]; then
   # Grub settings
   # Set grub timeout to 3 seconds
-  if [ -z $(grep "GRUB_TIMEOUT=" /etc/default/grub) ]; then
+  if ! grep -q "GRUB_TIMEOUT=" /etc/default/grub; then
     echo "GRUB_TIMEOUT=3" >> /etc/default/grub
   else
     sed -i 's/GRUB_TIMEOUT=[0-9]*/GRUB_TIMEOUT=3/' /etc/default/grub
   fi
 
   # Nuke hidden timeout as it will cause issues if GRUB_TIMEOUT exists
-  if [ -n $(grep "GRUB_HIDDEN_TIMEOUT=" /etc/default/grub) ]; then
+  if grep -q "GRUB_HIDDEN_TIMEOUT=" /etc/default/grub; then
     sed -i 's/GRUB_HIDDEN_TIMEOUT=[0-9]*//' /etc/default/grub
   fi
 


### PR DESCRIPTION
## Summary
- fix logic that checks for GRUB_TIMEOUT in `bazzite-hardware-setup`
- fix logic that removes GRUB_HIDDEN_TIMEOUT

## Testing
- `shellcheck system_files/desktop/shared/usr/libexec/bazzite-hardware-setup`

------
https://chatgpt.com/codex/tasks/task_e_685a8f99224c832d8a8c1be369229db9