### PR TITLE
Fix typo in hardware setup comment

### DIFF
--- a/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
+++ b/system_files/desktop/shared/usr/libexec/bazzite-hardware-setup
@@ -335,7 +335,7 @@ if grep -qv "graphical.target" <<< "$(systemctl get-default)"; then
 fi
 
 # Cleanup btrfs oopsie
-# default config has a 10 year limit, which is rediculous
+# default config has a 10 year limit, which is ridiculous
 # FIXME: This fix was added in 12/2024, remove it in a few months
 if [ ! -f /etc/bazzite/fixups/snapper_cleanup ] &&
   [ -f /etc/snapper/configs/root ] &&


### PR DESCRIPTION
## Summary
- correct the spelling of "ridiculous" in `bazzite-hardware-setup`

## Testing
- `grep -n "ridiculous" system_files/desktop/shared/usr/libexec/bazzite-hardware-setup`


------
https://chatgpt.com/codex/tasks/task_e_685a8f9a5e08832d8d17ce33932712ed